### PR TITLE
Add Bonds deployment under home namespace

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -30,6 +30,10 @@ vault.androz2091.fr {
     reverse_proxy http://vaultwarden.home.svc.cluster.local:80
 }
 
+bonds.androz2091.fr {
+    reverse_proxy http://bonds.home.svc.cluster.local:80
+}
+
 sabnzbd.androz2091.fr {
     reverse_proxy http://sabnzbd.sushiflix.svc.cluster.local:80
 }

--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: harbor.androz2091.fr/personal/bonds:latest
+          image: docker.io/androz2091/bonds:simon-version
           imagePullPolicy: Always
 
           env:

--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bonds
+  namespace: home
+  labels:
+    app: bonds
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: bonds
+  template:
+    metadata:
+      labels:
+        app: bonds
+    spec:
+      containers:
+        - name: bonds
+          image: harbor.androz2091.fr/personal/bonds:latest
+          imagePullPolicy: Always
+
+          env:
+            - name: APP_ENV
+              value: production
+            - name: APP_URL
+              value: https://bonds.androz2091.fr
+            - name: SERVER_HOST
+              value: 0.0.0.0
+            - name: SERVER_PORT
+              value: "8080"
+            - name: DB_DRIVER
+              value: postgres
+            - name: STORAGE_UPLOAD_DIR
+              value: /app/data/uploads
+            - name: BLEVE_INDEX_PATH
+              value: /app/data/bonds.bleve
+            - name: BACKUP_DIR
+              value: /app/data/backups
+            - name: BACKUP_CRON
+              value: "0 2 * * *"
+            - name: BACKUP_RETENTION
+              value: "30"
+          envFrom:
+            - secretRef:
+                name: bonds-secrets
+
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+
+          livenessProbe:
+            httpGet:
+              path: /api/instance/info
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /api/instance/info
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: bonds-data

--- a/cluster-manifests/home/bonds/pvc.yaml
+++ b/cluster-manifests/home/bonds/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bonds-data
+  namespace: home
+  labels:
+    app: bonds
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Gi

--- a/cluster-manifests/home/bonds/sealed-secrets.yaml
+++ b/cluster-manifests/home/bonds/sealed-secrets.yaml
@@ -1,0 +1,36 @@
+# Placeholder — must be sealed locally before applying. See README.md in this dir.
+#
+# Generate the real SealedSecret with:
+#
+#   kubectl create secret generic bonds-secrets \
+#     --namespace=home \
+#     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
+#     --from-literal=SETTINGS_ENC_KEY="$(openssl rand -hex 32)" \
+#     --from-literal=DB_DSN="host=postgresql.db.svc.cluster.local port=5432 user=bonds password=YOUR_BONDS_DB_PASSWORD dbname=bonds sslmode=disable" \
+#     --dry-run=client -o yaml \
+#   | kubeseal --controller-namespace kube-system --controller-name sealed-secrets \
+#              --format yaml > sealed-secrets.yaml
+#
+# Then add the namespace-wide annotation that the existing manifests carry:
+#   metadata.annotations."sealedsecrets.bitnami.com/namespace-wide": "true"
+#
+# Replace this file with the kubeseal output.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: bonds-secrets
+  namespace: home
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+spec:
+  encryptedData:
+    JWT_SECRET: REPLACE_WITH_SEALED_VALUE
+    SETTINGS_ENC_KEY: REPLACE_WITH_SEALED_VALUE
+    DB_DSN: REPLACE_WITH_SEALED_VALUE
+  template:
+    metadata:
+      name: bonds-secrets
+      namespace: home
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+    type: Opaque

--- a/cluster-manifests/home/bonds/sealed-secrets.yaml
+++ b/cluster-manifests/home/bonds/sealed-secrets.yaml
@@ -1,36 +1,20 @@
-# Placeholder — must be sealed locally before applying. See README.md in this dir.
-#
-# Generate the real SealedSecret with:
-#
-#   kubectl create secret generic bonds-secrets \
-#     --namespace=home \
-#     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
-#     --from-literal=SETTINGS_ENC_KEY="$(openssl rand -hex 32)" \
-#     --from-literal=DB_DSN="host=postgresql.db.svc.cluster.local port=5432 user=bonds password=YOUR_BONDS_DB_PASSWORD dbname=bonds sslmode=disable" \
-#     --dry-run=client -o yaml \
-#   | kubeseal --controller-namespace kube-system --controller-name sealed-secrets \
-#              --format yaml > sealed-secrets.yaml
-#
-# Then add the namespace-wide annotation that the existing manifests carry:
-#   metadata.annotations."sealedsecrets.bitnami.com/namespace-wide": "true"
-#
-# Replace this file with the kubeseal output.
+---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: bonds-secrets
-  namespace: home
   annotations:
     sealedsecrets.bitnami.com/namespace-wide: "true"
+  name: bonds-secrets
+  namespace: home
 spec:
   encryptedData:
-    JWT_SECRET: REPLACE_WITH_SEALED_VALUE
-    SETTINGS_ENC_KEY: REPLACE_WITH_SEALED_VALUE
-    DB_DSN: REPLACE_WITH_SEALED_VALUE
+    DB_DSN: AgAVOeOuyNxH8QuSuiHG9JP14bC/n2/HLddQF6l3+hUQdxoV0g0ZAYY/DrBNQg9l+3lIBbPux6xxQw+RSGoFxiJV/JbsoeeMuB1HrqXvSn1HsfQWWhqA7DZVW9vgsyJLXbepkX5eS77aXFtdjNAfkkw3a3X05MhqSVy6uooiMHaokBY8CS6C92LIxceR8ROufq1QR/AP34yoBX+P7kg1t0fFoNOmRPTTM+XlRwdzidq5s/XU5qFyv7X8V7L+3xj4W3LuBAOQWnxu6Ge1d5V1IwblSUsAfqLMVK6+715lY+LlA7/8rtNOgRa2fW4MVWk3Z9olbEuc48uxx2xdn2VFau4vivpWmXwS9TsZgLDVpavfCGtA53dm+DiyOvHfxaj+aq/GuVdDbObk3ojPFUfTe9gDVl6pYeTozWgICIbgqBqj4IQ8n/smn4J+fJi3hWYcOm/r4EADQvFy9jBQHPivzSmf888DfG/af3OZAnW9WSsNdzIKL/o7AeiCD83Yy86Qa5LAZA1CZ4l01K/u9DE3l9yCTMfkhL8amozEbKIm30u6gqQANoO3Ipp3cwJ8Jye+GHFjp9PEWfgApncpVepe19RydKX+2+mvaIMdCeZHTqqoiW56z3A8JgY1j/xGEPZf9HxHOoGqTLNIMZqaZ/ZdD6zPfMOEKhpnWhD8KZfkg3FvhKN9K8IN3Pgxd88a1OLahHxyglk3stcDToIqyvNXJ+2hd91pVq8H1Ps5AykTVAUCZ2Abgo4mvbCzLubh6HPEYQoIwxtLBibmIeidxBwbc0scovRya6ZMs7DWcfLNAy/QpImci+5RXw7LXdwPqq3cvyCG+2AobshVTfrzaRWMsg==
+    JWT_SECRET: AgA1nUQWUsOUPpem5QwxbaHdxk8sRDnhn6sm3f50fOCi5XIhZyqBpqwcow9YJkjItgViNvpYHQ6gpotL5xGohDfDxJ8wgraonxFaBetzBElPbftt/96IyVAXdoeAyqBQEIHTwTODmsiMp5KkHBcUa9sdc3VaflUTvTRLJW4kpQwMJvAvYjpeHEzUd0m20stuCgCdzirB5A75rHT90eCgVutjuE56kr/E4/S7YJuvQe+4dVE9rZAu7lzUWDympb3WLfSYz6BZw9WImbgy5VZlz2J2tHxWwkZbdxkUPHXAiXv/g6AnxvpWnjTrpavLthQdjWxy7mjXvIAdmGMDdAz1Axd25PgwMOKxB+rkYJbKyqWXL1Hknwo/VFs1J72YSQ42FW3y0seLxePBrrIMmuhLU2sjTz1bLeG4WpScg9TryZEMu9M0ZaEfDb7l5PHZVjb17SgjVMyYRO/Ad7ckypX9gV2Yn0cv7LlVq/x48CtrQP6oZhm/s098ndMUGkA+3yMCm5vC6X9G4QeI6JHfa5X+sDEkNFYZg6b+40shJfRKRqj7fd+roigWU2Z5/FFvDPi8iWIbvR0mSW0u5rxyY6bqnzubGKbSF85VFVxy3LaPWEvHY+bWXHx0epr8Rdsja6ZUWpBw+gJoTdInYjyrs9I87OTNLz+5mtlk17OGorUGeKfgo/ji/L1vHPQJfvpNwEbQa4PhJyCOyuIuUhzvw6Fq0L8MzTT8Y9z1x/XdqQyt1uFACVZkS9buMnClX0//2hpIjjrXXovopB6vg3s0meRTHQ==
+    SETTINGS_ENC_KEY: AgBlGsP2ikGzlFAnAlmiMRTH8InNg0o/QlI2OEyQkow5Meyx4PJibvLiULjcbmrjsejQvFLfmXEV4XmX7Z1z/OU0N9RydWUHAIOpkIs+h021iTuvcv/y7HpXozrp85cnyU/dH6IbdMJdFdQmPBwYQCQvgGbH+vaI22kvCEgezmYnW7A5SkHvHyfoy40t09lrd/GV5yYuAgR8Q4lmfGUEBk7Ew1E2pbw1zhecwRWBEgmyLtChsrbozHlhKePEBLcdwE6XBE7ZLELgp9AKxlYa73VQeowDwnyc16JXheG+XEAVcxmx0hHUFFDvFXoAxsW6DS7wuMu2IlXhEQRTvRbnKotAboLLB+7TMHe8IaL4ORwTfx83XnLCVTScUcH2PTB8wbxY1KhjLyueY1lSFhHbKC32c7nWaOIAuXyOBz5zF7XYzsiV0XpBx23uUrQJ7bk9jID5OedZdfie/zzEDZA1ChQAxlasWArYeIBxUVJ3o4aMU1dDNFKB24ffXhWYbx2MrnldmaXIjofGjj0nPsWAeZYXDSfIn+ZEjlU47VIjeIQbgj/0QudnmEw8isic3Z8JI9YwZNOMOa5ZRpp5vuxyslsthM7A6z6Qm8ZWMmkzh3d/a7cKF6RgqYcRVJzqWG6sak6kYLIoH9MPUrosH0zMPyzOIQu3t1zR9R8iholiLQ4PgUkTr+D9YsX+CbqBTBR6+/Z8DsSgC7Maa0ODC7Y3ldXVYT5eRIHpmnth0aEyDdeCMw39xn9mVPPhwZBDo7HP0qUS6tcoHze/Gd2UXEg=
   template:
     metadata:
-      name: bonds-secrets
-      namespace: home
       annotations:
         sealedsecrets.bitnami.com/namespace-wide: "true"
+      name: bonds-secrets
+      namespace: home
     type: Opaque

--- a/cluster-manifests/home/bonds/service.yaml
+++ b/cluster-manifests/home/bonds/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bonds
+  namespace: home
+  labels:
+    app: bonds
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: bonds
+  type: ClusterIP


### PR DESCRIPTION
## Summary
Deploys [Bonds](https://github.com/Androz2091/bonds) (self-hosted personal CRM, Go server + embedded React SPA) into the cluster, mirroring the vaultwarden/monica/umami pattern in \`home/\`.

- **Image**: \`docker.io/androz2091/bonds:simon-version\` with \`imagePullPolicy: Always\`. Built by Androz2091/bonds#3 on every push to \`simon-version\`.
- **Database**: shared Postgres at \`postgresql.db.svc.cluster.local:5432\`, DSN passed via sealed \`bonds-secrets\`.
- **Storage**: 10 Gi Longhorn PVC for uploads, Bleve search index, and daily backups.
- **Backups**: built-in cron at 02:00 UTC, 30-day retention. Longhorn snapshots cover the underlying PVC.
- **Health**: liveness/readiness on \`/api/instance/info\`.
- **Ingress**: \`bonds.androz2091.fr\` Caddyfile entry → \`bonds.home.svc.cluster.local:80\`.

## Prerequisites before this can deploy

- [x] Merge Androz2091/bonds#3 (Docker Hub CI workflow). **Keep the \`ci/docker-build\` branch.**
- [x] Set \`DOCKERHUB_USERNAME\` / \`DOCKERHUB_TOKEN\` secrets on the Bonds fork.
- [x] Trigger the workflow once (manual dispatch or any push to \`simon-version\`) so the first image lands at \`androz2091/bonds:simon-version\`.
- [ ] In Postgres, create the database and user:
  \`\`\`sql
  CREATE USER bonds WITH PASSWORD '<strong-password>';
  CREATE DATABASE bonds OWNER bonds;
  \`\`\`
- [ ] Seal \`bonds-secrets\` (instructions inline in \`sealed-secrets.yaml\`) and replace the placeholder file. The secret must contain \`JWT_SECRET\`, \`SETTINGS_ENC_KEY\`, and the \`DB_DSN\` libpq string:
  \`\`\`
  host=postgresql.db.svc.cluster.local port=5432 user=bonds password=<the-password-from-above> dbname=bonds sslmode=disable
  \`\`\`
- [ ] Add a DNS A record for \`bonds.androz2091.fr\` pointing at the cluster IP (if no wildcard).

## Iteration workflow after first deploy

- Push to \`simon-version\` → CI publishes new \`:simon-version\`, \`:sha-<short>\`, and \`:latest\` tags.
- To force a redeploy: \`kubectl rollout restart deployment/bonds -n home\`.
- For an auditable per-commit pin, swap \`:simon-version\` for \`:sha-<short>\` in \`deployment.yaml\` (ArgoCD will then redeploy on each manifest bump).

## Test plan

- [ ] After merging + prerequisites complete, ArgoCD shows the bonds Application as Synced/Healthy.
- [ ] \`https://bonds.androz2091.fr\` loads the login page.
- [ ] Create an account, create a vault, create a contact — verify Postgres is being written to.
- [ ] Upload a file — verify the PVC is being used.
- [ ] Wait until 02:00 UTC and confirm a backup zip lands in \`/app/data/backups\` inside the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)