### PR TITLE
security: reduce public attack surface in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,21 +1,15 @@
-argocd.androz2091.fr {
-    reverse_proxy http://argocd-server.argocd.svc.cluster.local:80
+(adminjs_auth) {
+    basicauth {
+        admin $2y$12$.T3FhLVeNE9qKmushm9MH.s4/ZoxJNqDdyyA2Jwjz2H.VTaD.3Yo6
+    }
 }
 
 tagger.androz2091.fr, timetagger.androz2091.fr {
     reverse_proxy http://timetagger.home.svc.cluster.local:80
 }
 
-pgadmin.androz2091.fr {
-    reverse_proxy http://pgadmin-pgadmin4.db.svc.cluster.local:80
-}
-
 plex.androz2091.fr:32400, plex.androz2091.fr {
     reverse_proxy http://plex.sushiflix.svc.cluster.local:80
-}
-
-radarr.androz2091.fr {
-    reverse_proxy http://radarr.sushiflix.svc.cluster.local:80
 }
 
 harbor.androz2091.fr {
@@ -34,31 +28,27 @@ bonds.androz2091.fr {
     reverse_proxy http://bonds.home.svc.cluster.local:80
 }
 
-sabnzbd.androz2091.fr {
-    reverse_proxy http://sabnzbd.sushiflix.svc.cluster.local:80
-}
-
-tautulli.androz2091.fr {
-    reverse_proxy http://tautulli.sushiflix.svc.cluster.local:80
-}
-
 qbt.androz2091.fr {
     reverse_proxy http://qbittorrent.sushiflix.svc.cluster.local:80
 }
 
 kolc-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://kolc-discord-bot.managed.svc.cluster.local:80
 }
 
 evolution-markets-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://evolution-markets-discord-bot.managed.svc.cluster.local:80
 }
 
 10mans-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://ten-mans-discord-bot.managed.svc.cluster.local:80
 }
 
 pokercode-quiz-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://pokercode-quiz-discord-bot.managed.svc.cluster.local:80
 }
 
@@ -89,10 +79,6 @@ haste.androz2091.fr {
 
 monica.androz2091.fr {
     reverse_proxy http://monica.home.svc.cluster.local:80
-}
-
-prometheus-grafana.androz2091.fr {
-    reverse_proxy http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80
 }
 
 photos.androz2091.fr {
@@ -128,20 +114,18 @@ overseerr.androz2091.fr {
     reverse_proxy http://overseerr.sushiflix.svc.cluster.local:80
 }
 
-sonarr.androz2091.fr {
-    reverse_proxy http://sonarr.sushiflix.svc.cluster.local:80
-}
-
 documents.androz2091.fr {
     reverse_proxy http://paperless.home.svc.cluster.local:80
 }
 
 stratos-gaming-club-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://stratos-gaming-club-discord-bot.managed.svc.cluster.local:80
     redir / /admin
 }
 
 theproptrade-adminjs.androz2091.fr {
+    import adminjs_auth
     reverse_proxy http://theproptrade-giveaways-discord-bot.managed.svc.cluster.local:80
 }
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ kubeseal --scope namespace-wide --cert https://raw.githubusercontent.com/Androz2
 kubectl -n somenamespace port-forward svc/someservice host-port:cluster-port`
 ```
 
+### Internal-only services (port-forward to access)
+
+These services used to be public but were removed from the `Caddyfile` for security. Port-forward them locally to access:
+
+| Service | URL after forwarding | Command |
+|---|---|---|
+| Argo CD | http://localhost:8080 | `kubectl -n argocd port-forward svc/argocd-server 8080:80` |
+| pgAdmin | http://localhost:8081 | `kubectl -n db port-forward svc/pgadmin-pgadmin4 8081:80` |
+| Grafana | http://localhost:8082 | `kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 8082:80` |
+| Radarr | http://localhost:8083 | `kubectl -n sushiflix port-forward svc/radarr 8083:80` |
+| Sonarr | http://localhost:8084 | `kubectl -n sushiflix port-forward svc/sonarr 8084:80` |
+| SABnzbd | http://localhost:8085 | `kubectl -n sushiflix port-forward svc/sabnzbd 8085:80` |
+| Tautulli | http://localhost:8086 | `kubectl -n sushiflix port-forward svc/tautulli 8086:80` |
+
 ### Enter a pod
 
 ```sh


### PR DESCRIPTION
## Summary
- Remove from public ingress (Caddyfile): `argocd`, `pgadmin`, `prometheus-grafana`, `radarr`, `sonarr`, `sabnzbd`, `tautulli`. Access via `kubectl port-forward` going forward.
- Add HTTP basic auth in front of all 6 `*-adminjs.androz2091.fr` client admin panels using a shared `(adminjs_auth)` Caddy snippet.
- README: add a table with copy-pasteable port-forward commands for the now-internal services.

## Credentials
Basic auth user is `admin`. Password was generated out-of-band and shared with the cluster owner — not in this PR.

## Test plan
- [ ] Caddy reloads cleanly with the new `Caddyfile` (validate with `caddy validate` or check pod logs after rollout)
- [ ] Removed hosts (argocd, pgadmin, grafana, radarr, sonarr, sabnzbd, tautulli) no longer resolve publicly
- [ ] Each `*-adminjs.androz2091.fr` prompts for basic auth and accepts the new credentials
- [ ] Confirm port-forward commands in the README work end-to-end