### PR TITLE
security: lock down personal services (monica, changedetection, paperless)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,12 @@
     }
 }
 
+(personal_auth) {
+    basicauth {
+        admin $2y$12$Xi5yYKOnTrbRiX8LsjC3aOFIU3DE7aus9ojRwFHnxFi1iPFrCzTny
+    }
+}
+
 tagger.androz2091.fr, timetagger.androz2091.fr {
     reverse_proxy http://timetagger.home.svc.cluster.local:80
 }
@@ -77,10 +83,6 @@ haste.androz2091.fr {
     reverse_proxy http://haste-server.pro.svc.cluster.local:80
 }
 
-monica.androz2091.fr {
-    reverse_proxy http://monica.home.svc.cluster.local:80
-}
-
 photos.androz2091.fr {
     reverse_proxy http://immich-server.home.svc.cluster.local:2283
 }
@@ -115,6 +117,7 @@ overseerr.androz2091.fr {
 }
 
 documents.androz2091.fr {
+    import personal_auth
     reverse_proxy http://paperless.home.svc.cluster.local:80
 }
 
@@ -135,10 +138,6 @@ pdfding.androz2091.fr {
 
 go.simonlefort.ch {
     reverse_proxy http://shlink.home.svc.cluster.local:80
-}
-
-changedetection.androz2091.fr {
-    reverse_proxy http://changedetection.home.svc.cluster.local:80
 }
 
 ninja.androz2091.fr {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ These services used to be public but were removed from the `Caddyfile` for secur
 | Sonarr | http://localhost:8084 | `kubectl -n sushiflix port-forward svc/sonarr 8084:80` |
 | SABnzbd | http://localhost:8085 | `kubectl -n sushiflix port-forward svc/sabnzbd 8085:80` |
 | Tautulli | http://localhost:8086 | `kubectl -n sushiflix port-forward svc/tautulli 8086:80` |
+| changedetection | http://localhost:8087 | `kubectl -n home port-forward svc/changedetection 8087:80` |
+| Monica | http://localhost:8088 | `kubectl -n home port-forward svc/monica 8088:80` |
 
 ### Enter a pod
 


### PR DESCRIPTION
Follow-up to #3.

## Summary
- Remove \`monica.androz2091.fr\` and \`changedetection.androz2091.fr\` from public ingress (single-user services — access via \`kubectl port-forward\`, see README).
- Add a separate \`(personal_auth)\` Caddy snippet and apply it to \`documents.androz2091.fr\` (paperless) so app-level auth isn't the only thing between the internet and the document store. Kept separate from \`(adminjs_auth)\` so the credential isn't shared with clients.
- README: add port-forward entries for monica and changedetection.

Basic-auth credential was generated out-of-band and shared with the cluster owner.

## Test plan
- [ ] \`monica.androz2091.fr\` and \`changedetection.androz2091.fr\` no longer resolve publicly
- [ ] \`documents.androz2091.fr\` prompts for basic auth before the paperless login appears
- [ ] Caddy reloads cleanly on rollout
- [ ] Status page expects 401 for paperless (see Androz2091/status#1634)