### PR TITLE
db: bump postgres 15.1 -> 15.18 + Recreate rollout strategy

### DIFF
--- a/cluster-manifests/db/postgres/deployment.yaml
+++ b/cluster-manifests/db/postgres/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: postgresql
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: postgresql
@@ -25,7 +27,7 @@ spec:
 
       containers:
         - name: postgresql
-          image: postgres:15.1
+          image: postgres:15.18
           ports:
             - name: postgresql
               containerPort: 5432


### PR DESCRIPTION
## Summary
- Bump postgres image from \`15.1\` to \`15.18\` (~17 patch releases of CVE/bug fixes — same on-disk format, no data migration needed).
- Set \`strategy.type: Recreate\` on the Deployment. With \`replicas: 1\` + RWO PVC, the default RollingUpdate causes a deadlock during rollout (new pod can't mount the volume because the old pod still owns it).

## Before merging / syncing
- [ ] Take a Longhorn snapshot of \`postgresql-pvc\` (port-forward the Longhorn UI, snapshot the volume).

## Expected impact
~30s of unavailability when Argo applies the change: the old pod terminates, then the new pod starts. Every dependent app will reconnect (Discord bots, paperless, monica, shlink, bonds, umami, haste, invoice ninja, manage-invite-bot).

## Test plan
- [ ] After sync, \`kubectl -n db logs deploy/postgresql\` shows clean startup, \`database system is ready to accept connections\`
- [ ] \`kubectl -n db exec deploy/postgresql -- psql -U postgres -c '\\\\l'\` lists existing databases unchanged
- [ ] Spot-check one consumer per group (e.g. one Discord bot, paperless, umami) reconnects cleanly