### PR TITLE
filebrowser: switch to official image, bump to v2.63.3

### DIFF
--- a/cluster-manifests/home/filebrowser/deployment.yaml
+++ b/cluster-manifests/home/filebrowser/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: filebrowser
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: filebrowser
@@ -17,14 +19,12 @@ spec:
     spec:
       containers:
         - name: filebrowser
-          image: hurlenko/filebrowser:v2.31.2
+          image: filebrowser/filebrowser:v2.63.3
           imagePullPolicy: IfNotPresent
-          # command: ["/bin/bash"]
-          # args: ["-c", "sleep 999999"]
-
-          # env:
-          #   - name: ROCKET_PORT
-          #     value: "4000"
+          args:
+            - --port=8080
+            - --root=/srv
+            - --database=/database/filebrowser.db
 
           ports:
             - containerPort: 8080
@@ -35,9 +35,9 @@ spec:
 
           volumeMounts:
             - name: filebrowser-data-v
-              mountPath: /data
+              mountPath: /srv
             - name: filebrowser-config-v
-              mountPath: /config
+              mountPath: /database
 
       volumes:
         - name: filebrowser-data-v


### PR DESCRIPTION
## Summary
Move \`home/filebrowser\` from the third-party \`hurlenko/filebrowser:v2.31.2\` fork to the official \`filebrowser/filebrowser:v2.63.3\`. ~32 minor versions of upstream fixes.

Backup of \`filebrowser-config-pvc\` already exists out-of-band.

## Changes
- Image: \`hurlenko/filebrowser:v2.31.2\` → \`filebrowser/filebrowser:v2.63.3\`
- Args added so the existing PVCs are reused without copying any data:
  - \`--port=8080\` (matches the Service \`targetPort\`)
  - \`--root=/srv\` (mounted from \`filebrowser-data-pvc\`)
  - \`--database=/database/filebrowser.db\` (mounted from \`filebrowser-config-pvc\`)
- Mount paths shifted from hurlenko's \`/data\` + \`/config\` to official's \`/srv\` + \`/database\`. Underlying PVCs are unchanged; \`filebrowser.db\` sits at the root of the config PVC so it lines up.
- Added \`strategy: Recreate\` to avoid the RWO rollout deadlock.

## Expected behavior on first start
Filebrowser auto-migrates the SQLite schema. ~30s downtime during the rollout.

## Test plan
- [ ] Pod becomes Ready, logs show schema migration completed
- [ ] \`cloud.androz2091.fr\` loads, existing users can log in
- [ ] File listing under \`/srv\` shows previous data intact
- [ ] If something is off: scale to 0, restore \`filebrowser.db\` from the backup, revert the PR