### PR TITLE
filebrowser: fix permission denied on /database/filebrowser.db

### DIFF
--- a/cluster-manifests/home/filebrowser/deployment.yaml
+++ b/cluster-manifests/home/filebrowser/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       labels:
         app: filebrowser
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: filebrowser
           image: filebrowser/filebrowser:v2.63.3


### PR DESCRIPTION
Follow-up to #6.

The image swap landed but filebrowser failed to start with:
\`\`\`
Error: open /database/filebrowser.db: permission denied
\`\`\`

The official image runs as \`filebrowser\` (UID 1000), whereas the previous \`hurlenko\` fork ran as root — so existing PVC files are root-owned and the new runtime user can't write to them.

## Fix
Add a pod \`securityContext\` so kubelet chgrp's the volume root on mount:
\`\`\`yaml
securityContext:
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
  fsGroupChangePolicy: OnRootMismatch
\`\`\`

## Test plan
- [ ] Pod becomes Ready
- [ ] Logs show no permission errors opening \`/database/filebrowser.db\`
- [ ] \`cloud.androz2091.fr\` loads, file listing under \`/srv\` is intact
- [ ] Upload a small file from the UI to confirm write paths work
- [ ] If individual files under \`/srv\` are still root-owned and unreadable, run a one-shot chown via the existing \`backup-filebrowser-mnt-data-pod\`: \`chown -R 1000:1000 /mnt/data\`