### PR TITLE
chore(bonds): bump image to sha-ccbbdd2

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:simon-version
+          image: docker.io/androz2091/bonds:sha-ccbbdd2
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Pin `cluster-manifests/home/bonds/deployment.yaml` to `androz2091/bonds:sha-ccbbdd2` (was floating `:simon-version`).
- Built from simon-version commit `ccbbdd2`, which merges naiba/bonds PR #118 (Quick Facts: render all template categories on the contact page).
- Source workflow run: https://github.com/Androz2091/bonds/actions/runs/25976854829

## Test plan
- [ ] ArgoCD/Flux (or manual `kubectl apply`) rolls the deployment
- [ ] Pod comes up healthy
- [ ] Contact page Quick Facts card shows grouped categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)