### PR TITLE
db: rotate postgres superuser password

### DIFF
--- a/cluster-manifests/db/postgres/sealed-secrets.yaml
+++ b/cluster-manifests/db/postgres/sealed-secrets.yaml
@@ -4,17 +4,15 @@ kind: SealedSecret
 metadata:
   annotations:
     sealedsecrets.bitnami.com/namespace-wide: "true"
-  creationTimestamp: null
   name: postgresql-secrets
   namespace: db
 spec:
   encryptedData:
-    postgres-password: AgCScd1yJ71pQyy6jGDJRo++1WDO9XIE/XVlMQyyc+s+6lXRpkR/E/tNXW2459T6cRlDbo79reP911suGpdd6GoXUm7aJMK42tFdcAP4ATM9Yd86KYtsqhtkvqyJtKt1Bmm+zGp4E3rT+yGPGgvQbl8IIW6isoyfSbN8EUGtxYA1DQKppxDTSj07j+/MadAOOSgGIsbZg+e3R2OngmqcAi6uSijvidfGSJg7zuI/80BfIOeS6757z9bB9ftHYTz8hzrAryitip1t7ZNc1/L3tH8CqPr9GkCPYRtMo/YKqzSWWgJtYCtbi4+/ZEvePhQtZH/jRLxb4rEoAmf6xaWEYywaiJ8S9nT0jCWmpA/eJR4UM3Hd4550eUvukHcmqQ2Ytf6QT/wRM4qB++aThzU9WlX/HPh+H9BLJyY1wPPWehQVx2zEapXM5yGM3l3u1RDWNMkY4rrLX6721eTfr3Hu8Eqe2gXRr38oBIBN3FnPUsGC4PUUHMgi3cmo8dWZSaE/eIRhjTIBIemJ7A0M/FlYBvkp1ZFHd0HQl08ChbComKe+WBfuNCimpB0KHZFvu4u9TgsZ6XXVlWlOFlvRbhi+XE1mm3EB/b5D/TLiwGZngJiLlVLtrTy5+xjurTB3545o1AgD7Mj0SmXkvvMRNcdrodWhO9AX7MQAgH/lVpfBi6p7zKUjyAsC3eXAXVAp7zkjQkLmTauEdsB8XzCyh2Mj
+    postgres-password: AgBL6k7d5h6Ur0+KxpkAmT+Xcwn4WP+N9s4D7ELMArGEpWUVfUYbmm4LWUBLTdhRALo3hhxf/tYtYQcv56ZqMSCcz9rsxfmq+mb56wTPpOPqAJAVJ2PfO0WBIz1UriCRggv87B8Lb9DGSpajaHy3fe3kF9r4SkCIA/0fWPuo+WXJnxzzUps0ovEAyTgoEJxXS/VNbQFvn8h2VqqD3BIPt8QUrNBdzmftPhf45vEUmX1og7t5Kb8H4lJ4FvsyK0djQvPC/EgSo7lXl5tWL2CDo3EQhnpz+s3GX13+xpFU/zDvuvfS6cfutlRqdHzECMOZYQylKk17vRbkAvAK/y7MqvQzqB9RAmptk2mto8jPF8oTjW0KatRj1xKVjyAOfozYem6xSj1crNBTZBYxDVnAa1Pzg9oS++4fwMzCTyZzp0ErTAvqds/PoeRhMfTTi5nGNmhwdQxlD61fyW8MfnHn4PtNbMLPe992jQqMe1UqWIYBLz034FQ9OVNonmJmE0VTQfkdHMpkb0nTEa8NtkKGZ9iAVLSeBqPyA7hWSbyu2uoDb6eFRIh6XgqwfO9uk78uZyaB1OVawej1ieYXyh2K8Jr9nyiJJYuAn8Li4o0G2o3AUTyAR5jwUeuc2T5mfPHs1suZjFN3j0VF9XwktfALxa8Q3Q3auufnwNPKVlFn16WNuxtSk8MiRCyR66bHSuB5L6B4txrUUQbID1KrjiM5XriOXq43wqIcgc4V45CXuO+DZhTNl0sd21lR
   template:
     metadata:
       annotations:
         sealedsecrets.bitnami.com/namespace-wide: "true"
-      creationTimestamp: null
       name: postgresql-secrets
       namespace: db
     type: Opaque


### PR DESCRIPTION
Final cleanup after the per-app role split (#8, #10, #11).

The shared superuser password used to live in every app's secret. Now that every workload uses its own role, the superuser is admin-only — and its password was rotated to invalidate the old shared one.

Already done out-of-band on the cluster:
\`\`\`sh
kubectl -n db exec -i deploy/postgresql -- psql -U postgres \\
  -c \"ALTER USER postgres WITH PASSWORD '<new>';\"
\`\`\`

This PR just re-seals the in-repo \`postgresql-secrets\` so the pod env stays in sync on restart (the POSTGRES_PASSWORD env var read on bootstrap should already match what we just set live).

## Test plan
- [ ] Argo syncs the sealed secret without producing churn
- [ ] If the postgres pod restarts, it comes back with the new password (env from sealed secret matches what's set on the role)
- [ ] Update the pgAdmin connection out-of-band to use the new password

## Out-of-band follow-up
Update the saved connection in pgAdmin (Object → Properties → Connection → new password) and remove the in-pgAdmin saved old password from any clients.