### PR TITLE
chore(bonds): bump image to sha-78c4a25

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-ccbbdd2
+          image: docker.io/androz2091/bonds:sha-78c4a25
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps `cluster-manifests/home/bonds/deployment.yaml` from `sha-ccbbdd2` to `sha-78c4a25`.
- New build adds the contact "needs verification" flag (closes naiba/bonds#119, upstream PR naiba/bonds#120, merged into simon-version).
- Source workflow run: https://github.com/Androz2091/bonds/actions/runs/25977755467

## Test plan
- [ ] Argo/Flux (or `kubectl apply`) rolls the deployment
- [ ] Pod healthy
- [ ] Contact create form shows the new "Needs verification" checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)