### PR TITLE
chore(bonds): bump image to sha-006b173 (debug)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-78c4a25
+          image: docker.io/androz2091/bonds:sha-006b173
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
Debug bump to surface the vault-delete cascade error in API responses. I'll revert to the prior SHA after we identify which cascade step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)