### PR TITLE
chore(bonds): bump image to sha-901d600 (vault delete fix)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-006b173
+          image: docker.io/androz2091/bonds:sha-901d600
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
Deploys the vault delete cascade fix (sha-901d600 on simon-version). After the previous debug bump revealed the FK error on ContactImportantDate, this commit switches the cascade to Unscoped() so soft-deleted children release their FKs and the cascade completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)