### PR TITLE
chore(bonds): bump image to sha-52bc9a7 (clean post-debug)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-951d522
+          image: docker.io/androz2091/bonds:sha-52bc9a7
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
Cleans up the temporary debug error surface on the vault delete handler now that the cascade is fixed. Same behaviour as sha-951d522 minus the leaked err.Error() in 500 responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)