### PR TITLE
Bump slash-commands-gui to 1.5.0

### DIFF
--- a/cluster-manifests/pro/slash-commands-gui/kustomization.yaml
+++ b/cluster-manifests/pro/slash-commands-gui/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     valuesInline:
       image:
         repository: androz2091/slash-commands-gui
-        tag: sha-2cf917f
+        tag: 1.5.0
       ports:
       - svcPort: 80
         name: http


### PR DESCRIPTION
Updates the slash-commands-gui image tag from sha-2cf917f to the 1.5.0 release.

The 1.5.0 image is built and available on Docker Hub. It includes the recent fixes (unicode names, shared choices, deletion bugs) and the new option types.