### PR TITLE
chore(bonds): bump image to sha-e3f11d5 (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-52bc9a7
+          image: docker.io/androz2091/bonds:sha-e3f11d5
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-52bc9a7` to `sha-e3f11d5`.
- This is the merge commit that pulls 87 upstream commits into `simon-version`: MCP backend, lunar calendar fields on tasks/posts/life events, i18n + locale fixes, CSV import, calendar-aware DAV exports, locked task-assignee mutations, task cascade delete, and cycle-safe parent validation.
- Source: Androz2091/bonds@e3f11d5.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate strategy, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes after rollout.
- [ ] Smoke-check the new lunar date pickers and locale switch on https://bonds.androz2091.fr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)