### PR TITLE
chore(bonds): bump image to sha-e129d00 (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-e3f11d5
+          image: docker.io/androz2091/bonds:sha-e129d00
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-e3f11d5` to `sha-e129d00`.
- Pulls 23 upstream commits into `simon-version`: French (fr) locale bundle, contact read/edit detail modes, "how we met" quick fact template + backfill, LinkifiedText for clickable URLs/emails/phones, age-at-death + typed email/phone display fixes.
- Source: Androz2091/bonds@e129d00.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate strategy, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes after rollout.
- [ ] Smoke-check French locale switch and contact read/edit toggle on https://bonds.androz2091.fr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)