### PR TITLE
chore(bonds): bump image to sha-6043d0b (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-e129d00
+          image: docker.io/androz2091/bonds:sha-6043d0b
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-e129d00` to `sha-6043d0b`.
- Pulls 39 upstream commits into `simon-version`: first-met contact metadata (backend + UI + sort + i18n), stay-in-touch UI + dashboard catch-up prompts, Monica export fidelity preservation, Shoutrrr notifications honoring preferred time, week-start preference, URL-synced list pagination, plus DAV fixes (reject cross-vault writes, unauthenticated discovery, user-id in URLs).
- Source: Androz2091/bonds@6043d0b.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes.
- [ ] Smoke-check first-met fields, stay-in-touch UI, and a DAV client connect on https://bonds.androz2091.fr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)