### PR TITLE
chore(bonds): bump image to sha-f88d3b4 (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-6043d0b
+          image: docker.io/androz2091/bonds:sha-f88d3b4
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-6043d0b` to `sha-f88d3b4`.
- Pulls 7 upstream commits into `simon-version`: calendar ICS endpoint with contact names in date summaries, PAT scope tests, web migrated to Vite 8 / TS 6 (75 npm packages bumped) with dependabot config, recurring reminders only scheduled for future occurrences, contact summary reorganization.
- Source: Androz2091/bonds@f88d3b4.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes.
- [ ] Smoke-check the contact summary layout and grab an ICS calendar feed via the new endpoint on https://bonds.androz2091.fr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)