### PR TITLE
feat(caddy): re-expose 6 internal services behind tinyauth

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -158,3 +158,33 @@ go.simonlefort.ch {
 ninja.androz2091.fr {
     reverse_proxy http://invoiceninja.pro.svc.cluster.local:80
 }
+
+changedetection.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://changedetection.home.svc.cluster.local:80
+}
+
+monica.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://monica.home.svc.cluster.local:80
+}
+
+prometheus-grafana.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80
+}
+
+radarr.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://radarr.sushiflix.svc.cluster.local:80
+}
+
+sonarr.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://sonarr.sushiflix.svc.cluster.local:80
+}
+
+tautulli.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://tautulli.sushiflix.svc.cluster.local:80
+}

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ Cluster-admin and DB-direct services that stay off the public internet. Port-for
 | pgAdmin | http://localhost:8081 | `kubectl -n db port-forward svc/pgadmin-pgadmin4 8081:80` |
 | SABnzbd | http://localhost:8085 | `kubectl -n sushiflix port-forward svc/sabnzbd 8085:80` |
 
-Other formerly-internal services (Grafana, Radarr, Sonarr, Tautulli, changedetection, Monica) are now exposed publicly behind [tinyauth](https://tinyauth.app) — see the `tinyauth_auth` snippet in the `Caddyfile`.
-
 ### Enter a pod
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -80,19 +80,15 @@ kubectl -n somenamespace port-forward svc/someservice host-port:cluster-port`
 
 ### Internal-only services (port-forward to access)
 
-These services used to be public but were removed from the `Caddyfile` for security. Port-forward them locally to access:
+Cluster-admin and DB-direct services that stay off the public internet. Port-forward them locally to access:
 
 | Service | URL after forwarding | Command |
 |---|---|---|
 | Argo CD | http://localhost:8080 | `kubectl -n argocd port-forward svc/argocd-server 8080:80` |
 | pgAdmin | http://localhost:8081 | `kubectl -n db port-forward svc/pgadmin-pgadmin4 8081:80` |
-| Grafana | http://localhost:8082 | `kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 8082:80` |
-| Radarr | http://localhost:8083 | `kubectl -n sushiflix port-forward svc/radarr 8083:80` |
-| Sonarr | http://localhost:8084 | `kubectl -n sushiflix port-forward svc/sonarr 8084:80` |
 | SABnzbd | http://localhost:8085 | `kubectl -n sushiflix port-forward svc/sabnzbd 8085:80` |
-| Tautulli | http://localhost:8086 | `kubectl -n sushiflix port-forward svc/tautulli 8086:80` |
-| changedetection | http://localhost:8087 | `kubectl -n home port-forward svc/changedetection 8087:80` |
-| Monica | http://localhost:8088 | `kubectl -n home port-forward svc/monica 8088:80` |
+
+Other formerly-internal services (Grafana, Radarr, Sonarr, Tautulli, changedetection, Monica) are now exposed publicly behind [tinyauth](https://tinyauth.app) — see the `tinyauth_auth` snippet in the `Caddyfile`.
 
 ### Enter a pod
 


### PR DESCRIPTION
## Summary
- Restores public access to **changedetection, monica, prometheus-grafana, radarr, sonarr, tautulli** at their pre-lockdown subdomains — same hostnames used before #3, now gated by `tinyauth_auth` instead of being unauthenticated.
- Removes those 6 entries from the README port-forward table.
- **Argo CD, pgAdmin, and SABnzbd stay port-forward-only** (cluster admin / DB direct / download-anything abuse risk — not worth re-exposing even behind tinyauth).

## DNS
Each hostname needs an A record pointing to the cluster IP. Most likely already in place (these were public historically), but worth double-checking:
- `changedetection.androz2091.fr`
- `monica.androz2091.fr`
- `prometheus-grafana.androz2091.fr`
- `radarr.androz2091.fr`
- `sonarr.androz2091.fr`
- `tautulli.androz2091.fr`

## Test plan
- [ ] `sudo systemctl reload caddy` on the host after merge
- [ ] Each subdomain prompts the tinyauth login if signed out, then lands on the upstream app's own login (existing per-app credentials still apply)
- [ ] No regressions on already-exposed apps (Paperless, SuperWaymo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)