### PR TITLE
chore(bonds): bump image to sha-5b1951c (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-f88d3b4
+          image: docker.io/androz2091/bonds:sha-5b1951c
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-f88d3b4` to `sha-5b1951c`.
- Pulls 2 upstream commits into `simon-version`: task assignee dropdown now searches the contacts API beyond the 200-row local cache; personalize sortable settings resequence cleanly on insert/move.
- Catches up the prior `9d13c7d` build that failed on a transient Docker Hub registry timeout.
- Source: Androz2091/bonds@5b1951c.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes.
- [ ] In a vault with >200 contacts, open a task's assignee dropdown and type a name only present beyond the first 200 — confirm it appears.
- [ ] Reorder personalize sortable settings and confirm positions persist correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)