### PR TITLE
feat(tinyauth): set custom login background

### DIFF
--- a/cluster-manifests/home/tinyauth/deployment.yaml
+++ b/cluster-manifests/home/tinyauth/deployment.yaml
@@ -30,6 +30,8 @@ spec:
               value: "https://auth.androz2091.fr"
             - name: TINYAUTH_DATABASE_PATH
               value: "/data/tinyauth.db"
+            - name: TINYAUTH_UI_BACKGROUNDIMAGE
+              value: "https://photos.androz2091.fr/api/assets/f555dced-a633-48be-b84b-ba475c8b2493/thumbnail?key=09zMecTGWSuy1epLVhWg1fXRhj8lJP1AdZ3-v2UGK-z3f2K7-_TDb1bjwIJIIcAKhOI&size=preview&c=mxgWDYJQindeh3iHeHeHh5z20ok%2F&edited=true"
           envFrom:
             - secretRef:
                 name: tinyauth-secrets


### PR DESCRIPTION
## Summary
Sets `TINYAUTH_UI_BACKGROUNDIMAGE` on the tinyauth deployment so the `auth.androz2091.fr` login page renders with a personal photo (shared Immich asset) instead of the default tinyauth wallpaper.

## How it works
tinyauth passes the value straight into a CSS `background-image: url(...)` rule, so any public HTTPS URL works — no volume mount or ConfigMap needed.

## Test plan
- [ ] After ArgoCD syncs, the tinyauth pod restarts and `https://auth.androz2091.fr` shows the new background.
- [ ] If the photo ever 404s or the share link is revoked, the page will fall back to a transparent background (still functional, just plain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)