### PR TITLE
chore(bonds): bump image to sha-017a405 (upstream merge, supersedes #32)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-f88d3b4
+          image: docker.io/androz2091/bonds:sha-017a405
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-f88d3b4` to `sha-017a405`.
- Supersedes #32 (still open, never merged) — this PR bundles those 2 commits plus the 15 new upstream commits since.
- Highlights: German (de) locale bundle, contact Gifts module, typed structured Quick Facts, vault display-name overrides through backend / DAV / contact list, vCard 4 support, nickname-only contacts, WebAuthn passkey fixes, task assignee dropdown searches contacts API beyond 200-row cache, personalize sortable resequence, BSL change-date update + contribution terms.
- Close #32 after this merges.
- Source: Androz2091/bonds@017a405.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly (Recreate, single replica).
- [ ] `/api/instance/info` returns 200 for liveness + readiness probes.
- [ ] Smoke-check the German locale switch, a contact's Gifts tab, a typed Quick Fact create, and a WebAuthn passkey login on https://bonds.androz2091.fr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)