### PR TITLE
chore(bonds): bump image to sha-f98248c (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-017a405
+          image: docker.io/androz2091/bonds:sha-f98248c
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-017a405` to `sha-f98248c`.
- Brings in the latest upstream merge from Bonds after the Docker image build completed successfully.
- Source: Androz2091/bonds@f98248c.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly.
- [ ] Liveness / readiness probes pass after rollout.
- [ ] Smoke-check the upstream merge behavior this bump enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)