### PR TITLE
chore(bonds): bump image to sha-080d7e5 (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-d10857c
+          image: docker.io/androz2091/bonds:sha-080d7e5
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-d10857c` to `sha-080d7e5`.
- Brings in the v0.15.3 upstream merge from Bonds after the Docker image build completed successfully.
- Source: Androz2091/bonds@080d7e5.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly.
- [ ] Liveness / readiness probes pass after rollout.
- [ ] Smoke-check the v0.15.3 contact promotion, first-met precision, and relationship hint changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)