### PR TITLE
chore(bonds): bump image to sha-a87d42f (upstream merge)

### DIFF
--- a/cluster-manifests/home/bonds/deployment.yaml
+++ b/cluster-manifests/home/bonds/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: bonds
-          image: docker.io/androz2091/bonds:sha-080d7e5
+          image: docker.io/androz2091/bonds:sha-a87d42f
           imagePullPolicy: Always
 
           env:


### PR DESCRIPTION
## Summary
- Bumps bonds image from `sha-080d7e5` to `sha-a87d42f`.
- Brings in the v0.15.6 upstream merge from Bonds after the Docker image build completed successfully.
- Source: Androz2091/bonds@a87d42f.

## Test plan
- [ ] ArgoCD picks up the new image and rolls out cleanly.
- [ ] Liveness / readiness probes pass after rollout.
- [ ] Smoke-check the v0.15.6 relationship edit, task sorting, and reminder date changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)