### PR TITLE
feat(home): add AirTrail

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -34,6 +34,11 @@ bonds.androz2091.fr {
     reverse_proxy http://bonds.home.svc.cluster.local:80
 }
 
+airtrail.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://airtrail.home.svc.cluster.local:80
+}
+
 superwaymo.androz2091.fr {
     import tinyauth_auth
     # /api/* → the node API (flush_interval -1 keeps the area-scan NDJSON stream live);

--- a/cluster-manifests/home/airtrail/deployment.yaml
+++ b/cluster-manifests/home/airtrail/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airtrail
+  namespace: home
+  labels:
+    app: airtrail
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: airtrail
+  template:
+    metadata:
+      labels:
+        app: airtrail
+    spec:
+      initContainers:
+        - name: init-uploads
+          image: busybox
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - chown -R 1000:1000 /app/uploads
+          volumeMounts:
+            - name: airtrail-uploads
+              mountPath: /app/uploads
+      containers:
+        - name: airtrail
+          image: johly/airtrail:v3.11.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ORIGIN
+              value: https://airtrail.androz2091.fr
+            - name: UPLOAD_LOCATION
+              value: /app/uploads
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airtrail-secrets
+                  key: DB_URL
+          ports:
+            - containerPort: 3000
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: airtrail-uploads
+              mountPath: /app/uploads
+          resources: {}
+      volumes:
+        - name: airtrail-uploads
+          persistentVolumeClaim:
+            claimName: airtrail-uploads-pvc

--- a/cluster-manifests/home/airtrail/pvc.yaml
+++ b/cluster-manifests/home/airtrail/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airtrail-uploads-pvc
+  namespace: home
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/cluster-manifests/home/airtrail/sealed-secrets.yaml
+++ b/cluster-manifests/home/airtrail/sealed-secrets.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  name: airtrail-secrets
+  namespace: home
+spec:
+  encryptedData:
+    DB_URL: AgCoTztTMT8Ets+MjfJx8AL82LB9wvP+9GsZ/WxhNJkqSsUoAS+8RI18ySDGX13L3O8L49gXUWqEPt4sK44GPCd0kip17EhM5y6ysNZN4SGac3xgMp5XaKcKYzR4zvz9+IVG0zSRjnh6EnXdBfaRBHh19eke0younZT6s+efK/psYLIPBrU4+6SIjo9fiYDq8xbZbUjgavyTpV4FutlRl3IVqieuQ3y3QC+s+9ntovLNrgUruf3h3VSxtErCXcghavD84U+YDk07kIzXFLD6FNI153FfYnxxF+ILRIqMWgJGuVuWASg1eN7Ra8lxMemLnko/yN+rFC1ghnV/jgjkjd3C1KK3Eh90Kzjd3CadGmoo7EiLrXH/+xnIIishOAiSz33AgrNMCq4wnsStF+uVLViD9GH8qoI5YWl3lZHMqUiYXPwq97e3bU9pXA56KUkKe/HqIsJX34C8OY8gacYZelxTErD2+nftP00/EQfHIZFWskxjDyMKic2Lmkj5PTOixp/BN7XFWzJQm8eO7C/LOD4qyxSwUqpvSYbOh7M5ZmxQlVmz1RIX/ZuyYAYFN8ESbVS+qON4RRBm38CYHD+QCMVWO7sYzoM2yzL155qgIVeNm/s29qsZri0qpHp6AabbfToPdZcIN5kK0PLrTg6FoWGTbfyGRH2sZWqsjXYO7dOedEoC64qkvo8gtnIfDC37V8dC1rLgLWgd/kgHa9wFyMcM9HzpmB+E9ZREwMSzEnae0SzmZU2/LpycmamqzIyxB+7zHAXP1h9uN/PLpIdIcqmeHjy/ZLtJnSBlMH0aeE8UgPJGQqKM+CCD8dr6E9qNkgprSA==
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      labels:
+        app: airtrail
+      name: airtrail-secrets
+      namespace: home
+    type: Opaque

--- a/cluster-manifests/home/airtrail/service.yaml
+++ b/cluster-manifests/home/airtrail/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: airtrail
+  namespace: home
+  labels:
+    app: airtrail
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: airtrail


### PR DESCRIPTION
## Summary
- add AirTrail as a home namespace app using johly/airtrail:v3.11.1
- add a 5Gi uploads PVC and sealed DB_URL secret
- expose airtrail.androz2091.fr behind existing tinyauth in Caddy

## Validation
- kubectl apply --dry-run=client -f cluster-manifests/home/airtrail/deployment.yaml -f cluster-manifests/home/airtrail/service.yaml -f cluster-manifests/home/airtrail/pvc.yaml -f cluster-manifests/home/airtrail/sealed-secrets.yaml

## Notes
- The live Postgres role/database airtrail has already been created on the existing db Postgres instance.
- AirTrail appears to be flight-only upstream; no train support was found in the README or OpenAPI.