### PR TITLE
Bump vaultwarden to 1.37.0

### DIFF
--- a/cluster-manifests/home/vaultwarden/deployment.yaml
+++ b/cluster-manifests/home/vaultwarden/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: vaultwarden
-          image: vaultwarden/server:1.35.7
+          image: vaultwarden/server:1.37.0
           imagePullPolicy: IfNotPresent
           # command: ["/bin/bash"]
           # args: ["-c", "sleep 999999"]


### PR DESCRIPTION
## Summary
- bump Vaultwarden image from 1.35.7 to 1.37.0

## Validation
- kubectl create --dry-run=client --validate=false -f cluster-manifests/home/vaultwarden
- git diff --check