### PR TITLE
fix(sushiflix): harden qBittorrent storage health

### DIFF
--- a/cluster-manifests/sushiflix/qbittorrent/deployment.yaml
+++ b/cluster-manifests/sushiflix/qbittorrent/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: qbittorrent
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: qbittorrent
@@ -15,6 +17,7 @@ spec:
       labels:
         app: qbittorrent
     spec:
+      hostname: qbittorrent
       containers:
         - name: qbittorrent
           image: lscr.io/linuxserver/qbittorrent:5.2.0
@@ -30,10 +33,32 @@ spec:
             - name: WEBUI_PORT
               value: "8080"
           ports:
-            - containerPort: 8080
-            - containerPort: 6881
-            - containerPort: 6881
+            - name: http
+              containerPort: 8080
+            - name: bittorrent-tcp
+              containerPort: 6881
+            - name: bittorrent-udp
+              containerPort: 6881
               protocol: UDP
+
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 2
+          livenessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 2
 
           resources: {}
 

--- a/cluster-manifests/sushiflix/qbittorrent/pvc.yaml
+++ b/cluster-manifests/sushiflix/qbittorrent/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 100Mi
+      storage: 1Gi


### PR DESCRIPTION
## Summary

- expand the qBittorrent config PVC from 100Mi to 1Gi
- use a Recreate rollout and stable hostname to avoid overlapping instances and stale profile locks
- add startup, readiness, and liveness probes so qBittorrent process failures are visible to Kubernetes
- name the container ports used by the probes

## Validation

- git diff --check
- kubectl server-side dry run in the sushiflix namespace

## Incident context

A stale qBittorrent profile lock caused the supervised application process to start and exit repeatedly while the pod remained Ready. The resulting log churn filled the 100Mi config PVC.