### PR TITLE
feat(caddy): expose SABnzbd behind TinyAuth

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -166,6 +166,11 @@ prometheus-grafana.androz2091.fr {
     reverse_proxy http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80
 }
 
+sabnzbd.androz2091.fr {
+    import tinyauth_auth
+    reverse_proxy http://sabnzbd.sushiflix.svc.cluster.local:80
+}
+
 radarr.androz2091.fr {
     import tinyauth_auth
     reverse_proxy http://radarr.sushiflix.svc.cluster.local:80

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Cluster-admin and DB-direct services that stay off the public internet. Port-for
 |---|---|---|
 | Argo CD | http://localhost:8080 | `kubectl -n argocd port-forward svc/argocd-server 8080:80` |
 | pgAdmin | http://localhost:8081 | `kubectl -n db port-forward svc/pgadmin-pgadmin4 8081:80` |
-| SABnzbd | http://localhost:8085 | `kubectl -n sushiflix port-forward svc/sabnzbd 8085:80` |
 
 ### Enter a pod
 


### PR DESCRIPTION
## Summary

- expose SABnzbd at sabnzbd.androz2091.fr
- protect the route with the existing TinyAuth forward-auth snippet
- remove SABnzbd from the internal-only services documentation

## Validation

- git diff --check
- verified the SABnzbd service target and Caddy block structure