### PR TITLE
home(immich): upgrade to v3.1.0

### DIFF
--- a/cluster-manifests/home/immich/kustomization.yaml
+++ b/cluster-manifests/home/immich/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     valuesInline:
       useDeprecatedPostgresChart: true
       image:
-        tag: v2.7.5
+        tag: v3.1.0
       immich:
         persistence:
           library:
@@ -43,6 +43,7 @@ helmCharts:
 
       env:
         DB_HOSTNAME: immich-postgresql.home.svc.cluster.local
+        IMMICH_MEDIA_LOCATION: /usr/src/app/upload
         REDIS_HOSTNAME: immich-redis-master.home.svc.cluster.local
 
 namespace: home


### PR DESCRIPTION
## Summary

- upgrade Immich server and machine-learning images from v2.7.5 to v3.1.0
- explicitly retain /usr/src/app/upload as the media location used by the existing chart and PVC
- leave the Helm chart, PostgreSQL, and Redis versions unchanged

## Validation

- rendered Helm chart 0.9.0 with the updated values
- validated both Immich deployments use v3.1.0
- validated the server library mount and IMMICH_MEDIA_LOCATION remain /usr/src/app/upload
- confirmed the live database uses VectorChord and has no schema drift before upgrade

## Rollout notes

- upgrade mobile clients to v3 before the server
- an automated database backup from 2026-08-15 is present
- prefer selectively syncing the two Immich deployments in Argo CD; the application already has unrelated drift on the generated PostgreSQL Secret
- monitor server startup migrations and verify login, upload, search, and machine learning after rollout

The Helm chart upgrade is intentionally deferred because chart 0.10.0 and later remove the embedded PostgreSQL and Redis dependencies and require a separate migration.
